### PR TITLE
Add Settings row to home page

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -5,10 +5,9 @@ Personal travel expense tracking PWA. Next.js 15 + TypeScript frontend,
 Neon (Postgres) for DB, Auth.js for auth, Vercel Blob for storage, deployed on Vercel.
 
 ## Branch strategy
-- `main` → GitHub Pages (existing app, keep untouched)
-- `fullstack` → new full-stack app (based on `main-backup-vercel-setup`), Vercel watches this branch
+- `main` → full-stack app, Vercel watches this branch (auto-deploys on push)
+- `fullstack` → legacy integration branch (predecessor to `main`); no longer the deploy target
 - Trip-specific work (Japan 2025, etc.) → branch off `main`, merge back as usual
-- When fullstack app is ready to replace old one: merge `fullstack` → `main`
 
 ## Package manager: pnpm (not yarn, not npm)
 Always use `pnpm` for installs and scripts.
@@ -45,7 +44,7 @@ Always use `pnpm` for installs and scripts.
 - `local-app-alpha` branch has useful reference: pg pool connection pattern in app/api/db-app/
 
 ## Deploying
-Push to `fullstack` → Vercel auto-deploys. No manual steps.
+Push to `main` → Vercel auto-deploys. No manual steps.
 
 ## Detailed architecture plan
 See .claude/docs/architecture.md

--- a/app/gustavo/page.tsx
+++ b/app/gustavo/page.tsx
@@ -25,6 +25,12 @@ const apps = [
         icon: 'IconHeartbeat',
         bg: '#f0b8b4',
     },
+    {
+        name: 'Settings',
+        href: '/gustavo/settings',
+        icon: 'IconSettings',
+        bg: '#cdd9e3',
+    },
 ]
 
 export default function GustavoHomePage() {


### PR DESCRIPTION
## Summary
- Adds a third stacked row to `/gustavo` (the home page), linking to `/gustavo/settings`
- Reuses the existing `apps` array pattern — same neo-brutalist row styling as Trips and Health
- Uses `IconSettings` (the same Tabler icon the footer menu uses for the settings button)
- Icon circle background is `#cdd9e3`, a pale blue chosen to harmonize with `colors.primaryBlue` and stay in the muted-pastel range used by the other two rows
- Also updates `.claude/CLAUDE.md` to reflect that Vercel now deploys off `main` (not `fullstack`)

## Test plan
- [ ] Run `pnpm dev`, open `/gustavo`, confirm three rows render: Trips, Health, Settings
- [ ] Tap the Settings row → routes to `/gustavo/settings`
- [ ] Verify the settings icon matches the one in the footer menu
- [ ] Confirm hover/active press-down state matches the other rows

https://claude.ai/code/session_01DL4FRF64yCsT4hZZUMBKj9